### PR TITLE
Property binding improvements.

### DIFF
--- a/src/ObservableProperty.Test/Tests.fs
+++ b/src/ObservableProperty.Test/Tests.fs
@@ -6,6 +6,7 @@ open System
 open System.Reactive
 open System.Reactive.Subjects
 open System.Reactive.Linq
+open System.Reactive.Concurrency
 
 open System.Reactive.Properties
 open System.Reactive.Properties.Operators
@@ -73,7 +74,7 @@ type Tests () =
         let a = newOP 0
         let b = newOP 0
 
-        let binding = (a, id) @~> b
+        let binding = a >!~> b <| id
 
         a <~ 5
         Assert.Equal(5, !!b)
@@ -107,7 +108,7 @@ type Tests () =
         let a = [1; 2; 3; 4].ToObservable()
         let b = newOP 0
 
-        let binding = (a.AsProperty(0), id) @~> b
+        let binding = a.AsProperty(0) >!~> b <| id
 
         Assert.Equal(4, !!b)
 


### PR DESCRIPTION
There are several important changes.

1) The properties are bound through a Scheduler.Default by default. I
think this is a more desired default behavior as binding through
Scheduler.Immediate directly affects the call site of the property setter
-- i.e. the owner. I think a more reasonable default is isolation, which
is provided by means of scheduling property value propagation on a
platform-default scheduler, which is usually asynchronous.

2) Added overloads/functions to specify explicitly the scheduler used to
propagate property changes. Perhaps more work in this direction would be
beneficiary as the syntax starts to become too verbose. Maybe we should
look into 'fluent syntax' possibilities.

3) Changed property binding operator names. Completely subjective, but I
think <~< looks better than <~@.
